### PR TITLE
Change default permissions of host_volumes to 0755

### DIFF
--- a/tasks/host_volume.yml
+++ b/tasks/host_volume.yml
@@ -4,5 +4,5 @@
     owner: "{{ item['owner'] | default(nomad_user) }}"
     group: "{{ item['group'] | default(nomad_group) }}"
     state: directory
-    mode: "{{ item['mode'] | default('0644') }}"
+    mode: "{{ item['mode'] | default('0755') }}"
   with_items: "{{ nomad_host_volumes }}"


### PR DESCRIPTION
Since these are directories, default permissions of 644 rather than 755 make little sense. Maybe creation/modification should be made optional via a flag. Or maybe remove the `perm` part alltogether - when mapping to existing directories it's really easy to miss setting this parameter and either breaking or mistakenly exposing things when permissions are changed.