### PR TITLE
add authoritative_region

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ The role defines most of its variables in `defaults/main.yml`:
 - Encryption secret for gossip communication
 - Default value: **""**
 
+### `nomad_authoritative_region`
+
+- Specifies the authoritative region, which provides a single source of truth for global configurations such as ACL Policies and global ACL tokens.
+- Default value: **""**
+
 ### `nomad_node_class`
 
 - Nomad node class

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,7 +57,6 @@ nomad_node_gc_threshold: "24h"
 nomad_job_gc_threshold: "4h"
 nomad_eval_gc_threshold: "1h"
 nomad_encrypt: ""
-nomad_authoritative_region: ""
 
 #### Client settings
 nomad_node_class: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ nomad_node_gc_threshold: "24h"
 nomad_job_gc_threshold: "4h"
 nomad_eval_gc_threshold: "1h"
 nomad_encrypt: ""
+nomad_authoritative_region: ""
 
 #### Client settings
 nomad_node_class: ""

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -5,6 +5,10 @@ server {
         bootstrap_expect = {{ nomad_bootstrap_expect }}
     {%- endif %}
 
+    {% if nomad_use_consul != "" %}
+        authoritative_region = "{{ nomad_authoritative_region }}"
+    {% endif %}
+
 {% if nomad_use_consul == False %}
     {% if nomad_retry_join | bool -%}
         retry_join = [

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -5,8 +5,8 @@ server {
         bootstrap_expect = {{ nomad_bootstrap_expect }}
     {%- endif %}
 
-    {% if nomad_use_consul != "" %}
-        authoritative_region = "{{ nomad_authoritative_region }}"
+    {% if nomad_authoritative_region is defined %}
+authoritative_region = "{{ nomad_authoritative_region }}"
     {% endif %}
 
 {% if nomad_use_consul == False %}


### PR DESCRIPTION
https://github.com/dockpack/ansible-nomad/issues/79
We need to add authoritative_region when using multi-region ACL.
https://nomadproject.io/guides/security/acl/#configuring-acls