### PR TITLE
add rpc_upgrade_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,21 @@ in many Ansible versions, so this feature might not always work.
 - Use a key for tls connection, nomad_cert_file and nomad_key_file are needed
 - Default value: **""**
 
+### `nomad_rpc_upgrade_mode`
+
+- Use a certificate for tls connection, nomad_ca_file and nomad_key_file are needed, used only when the cluster is being upgraded to TLS, and removed after the migration is complete. This allows the agent to accept both TLS and plaintext traffic.
+- Default value: **false**
+
+### `nomad_verify_server_hostname`
+
+- Use a key for tls connection, nomad_cert_file and nomad_key_file are needed. Specifies if outgoing TLS connections should verify the server's hostname.
+- Default value: **true**
+
+### `nomad_verify_https_client`
+
+- Use a key for tls connection, nomad_cert_file and nomad_key_file are needed. Specifies agents should require client certificates for all incoming HTTPS requests. The client certificates must be signed by the same CA as Nomad.
+- Default value: **true**
+
 #### Custom Configuration Section
 
 As Nomad loads the configuration from files and directories in lexical order,

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -142,5 +142,6 @@ nomad_docker_dmsetup: true
 nomad_ca_file: ""
 nomad_cert_file: ""
 nomad_key_file: ""
+nomad_rpc_upgrade_mode: false
 nomad_verify_server_hostname: true
 nomad_verify_https_client: true

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -56,6 +56,7 @@ tls {
     ca_file = "{{ nomad_ca_file }}"
     cert_file = "{{ nomad_cert_file }}"
     key_file = "{{ nomad_key_file }}"
+    rpc_upgrade_mode = {{ nomad_rpc_upgrade_mode }}
     verify_server_hostname = "{{ nomad_verify_server_hostname }}"
     verify_https_client = "{{ nomad_verify_https_client }}"
 }


### PR DESCRIPTION
Add rpc_upgrade_mode, we use it when upgrading nomad from no TLS to TLS.
https://learn.hashicorp.com/nomad/transport-security/enable-tls#rpc-upgrade-mode-for-nomad-servers

https://nomadproject.io/docs/configuration/tls/
#81 