### PR TITLE
cgroup-bin deprecated #75

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,7 @@
 # File: vars/Debian.yml - Debian OS variables for Nomad
 
 nomad_os_packages:
-  - cgroup-bin
+  - cgroup-tools
   - curl
   - git
   - libcgroup1


### PR DESCRIPTION
cgroup-bin is now a shell package only to pull in cgroup-tools. #75