### PR TITLE
Fix undefined nomad_telemetry variable #92

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,11 @@ in many Ansible versions, so this feature might not always work.
 - Use a key for tls connection, nomad_cert_file and nomad_key_file are needed. Specifies agents should require client certificates for all incoming HTTPS requests. The client certificates must be signed by the same CA as Nomad.
 - Default value: **true**
 
+### `nomad_telemetry`
+
+- Specifies whether to enable Nomad's telemetry configuration.
+- Default value: **false**
+
 ### `nomad_telemetry_disable_hostname`
 
 - Specifies if gauge values should be prefixed with the local hostname.

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -82,7 +82,7 @@ vault {
     token = "{{ nomad_vault_token }}"
 }
 
-{% if nomad_telemetry | bool == True %}
+{% if nomad_telemetry | default(False) | bool == True %}
 telemetry {
     disable_hostname = "{{ nomad_telemetry_disable_hostname | default("false") }}"
     collection_interval = "{{ nomad_telemetry_collection_interval | default("1s") }}"


### PR DESCRIPTION
Set default value for `nomad_telemetry` variable in base.hcl to `false`.

Fixes #92