### PR TITLE
Improve Vault Support for Namespace, Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,12 @@ in many Ansible versions, so this feature might not always work.
 
 ### `nomad_vault_token`
 
-- Vault token used by nomad
+- Vault token used by nomad. Will only be installed on servers.
+- Default value: **""**
+
+### `nomad_vault_namespace`
+
+- Vault namespace used by nomad
 - Default value: **""**
 
 ### `nomad_docker_enable`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,6 +152,7 @@ nomad_vault_key_file: ""
 nomad_vault_tls_server_name: ""
 nomad_vault_tls_skip_verify: false
 nomad_vault_token: ""
+nomad_vault_namespace: ""
 
 ### Docker
 nomad_docker_enable: "{{ lookup('env','NOMAD_DOCKER_ENABLE') | default('false', true) }}"

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -77,7 +77,10 @@ vault {
     key_file = "{{ nomad_vault_key_file }}"
     tls_server_name = "{{ nomad_vault_tls_server_name }}"
     tls_skip_verify = {{ nomad_vault_tls_skip_verify | bool | lower }}
+{%if nomad_node_role != 'client' %}
     token = "{{ nomad_vault_token }}"
+{% endif %}
+    namespace = "{{ nomad_vault_namespace }}"
 }
 
 {% if nomad_telemetry | default(False) | bool == True %}


### PR DESCRIPTION
This adds support for Vault namespaces (from Vault Enterprise).
Additionally, this ensures that a vault token is not installed on client
nodes. Per the nomad documentation, this token only needs be installed
on servers, and tokens will be delegated appropriately to client nodes.

Addresses https://github.com/ansible-community/ansible-nomad/issues/101