### PR TITLE
Fix After and Wants to start after networking

### DIFF
--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -11,8 +11,8 @@
 [Unit]
 Description=nomad agent
 Documentation=https://nomadproject.io/docs/
-Wants=basic.target
-After=basic.target network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User={{ nomad_user }}


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/ this is the correct way to start a service only after the network has come all the way up.
According to https://www.freedesktop.org/software/systemd/man/systemd.special.html#basic.target "systemd automatically adds dependency of the type After= for this target unit to all services (except for those with DefaultDependencies=no)", therefore having it here is redundant.