### PR TITLE
Add automatic encryption key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,14 @@ The role defines most of its variables in `defaults/main.yml`:
 - Deployment garbage collection threshold
 - Default value: **1h**
 
+### `nomad_encrypt_enable`
+
+- Enable Gossip Encryption even if `nomad_encrypt` is not set
+- Default value: false
+
 ### `nomad_encrypt`
 
-- Encryption secret for gossip communication
+- Set the encryption key; should be the same across a cluster. If not present and `nomad_encrypt_enable` is true, the key will be generated & retrieved from the bootstrapped server.
 - Default value: **""**
 
 ### `nomad_raft_protocol`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,7 +83,7 @@ nomad_node_gc_threshold: "24h"
 nomad_job_gc_threshold: "4h"
 nomad_eval_gc_threshold: "1h"
 nomad_deployment_gc_threshold: "1h"
-nomad_encrypt: ""
+nomad_encrypt_enable: "{{ lookup('env','NOMAD_ENCRYPT_ENABLE') | default('false', true) }}"
 nomad_raft_protocol: 2
 
 #### Client settings

--- a/tasks/get_gossip_key.yml
+++ b/tasks/get_gossip_key.yml
@@ -1,0 +1,73 @@
+- block:
+    - block:
+        - name: Check for server configuration
+          stat:
+            path: "{{ nomad_config_dir }}/server.hcl"
+          register: server_config_state
+          ignore_errors: true
+
+        - block:
+            - name: Check for gossip encryption key on previously boostrapped server
+              shell: grep encrypt {{ nomad_config_dir }}/server.hcl | awk '{print $3}' | sed -e 's/^"//' -e 's/"$//'
+              register: nomad_raw_key_result
+              ignore_errors: true
+
+            - name: Save gossip encryption key from existing configuration
+              set_fact:
+                nomad_encrypt: "{{ nomad_raw_key_result.stdout }}"
+          no_log: true
+          when:
+            - server_config_state.stat.exists | bool
+      when:
+        - nomad_encrypt is not defined
+
+      # Key provided by extra vars or the above block
+    - name: Write gossip encryption key locally for use with new servers
+      copy:
+        content: "{{ nomad_encrypt }}"
+        dest: '/tmp/nomad_raw.key'
+        mode: 0600
+      become: false
+      vars:
+        ansible_become: false
+      no_log: true
+      delegate_to: localhost
+      changed_when: false
+      when: nomad_encrypt is defined
+
+      # Generate new key if none was found
+    - block:
+        - name: Generate gossip encryption key
+          shell: "nomad operator keygen"
+          register: nomad_keygen
+
+        - name: Write key locally to share with other nodes
+          copy:
+            content: "{{ nomad_keygen.stdout }}"
+            dest: '/tmp/nomad_raw.key'
+            mode: 0600
+          become: false
+          vars:
+            ansible_become: false
+          delegate_to: localhost
+      no_log: true
+      run_once: true
+      when:
+      - lookup('first_found', dict(files=['/tmp/nomad_raw.key'], skip=true)) | ternary(false, true)
+      - not server_config_state.stat.exists | bool
+
+    - name: Read gossip encryption key for servers that require it
+      set_fact:
+        nomad_encrypt: "{{ lookup('file', '/tmp/nomad_raw.key') }}"
+      no_log: true
+      when:
+      - nomad_encrypt is not defined
+
+    - name: Delete gossip encryption key file
+      file:
+        path: '/tmp/nomad_raw.key'
+        state: absent
+      run_once: true
+      delegate_to: localhost
+      changed_when: false
+  no_log: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,13 @@
   notify:
     - restart nomad
 
+- name: Get Gossip Key
+  include: get_gossip_key.yml
+  when:
+    - _nomad_node_server | bool
+    - nomad_encrypt_enable | bool
+    - nomad_encrypt is not defined
+
 - name: Server configuration
   template:
     src: server.hcl.j2

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -41,7 +41,7 @@ authoritative_region = "{{ nomad_authoritative_region }}"
     job_gc_threshold = "{{ nomad_job_gc_threshold }}"
     deployment_gc_threshold = "{{ nomad_deployment_gc_threshold }}"
 
-    encrypt = "{{ nomad_encrypt }}"
+    encrypt = "{{ nomad_encrypt | default('') }}"
 
     raft_protocol = {{ nomad_raft_protocol }}
 }


### PR DESCRIPTION
Tasks
-----
Add task file for reading or generating thye gossip encryption key
Include the new task file for servers when nomad_encrypt_enable is true and nomad_encrypt is not defined

Parameters
----------
Add a new parameter nomad_encrypt_enable to force the creating of the encryption key
nomad_encrypt_enable may also be set with the environment variable NOMAD_ENCRYPT_ENABLE
nomad_encrypt is no longer defined by default
Maintain backward compatability (Playbooks that set nomad_encrypt do not need to change)

Templates
---------
server.hcl.js - Since nomad_encrypt is no longer defined by default, use jinja2 default filter

Fixes #68