### PR TITLE
Allow running the role even if not all instances are connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The role defines most of its variables in `defaults/main.yml`:
 - Nomad debug mode
 - Default value: **no**
 
+### `nomad_skip_ensure_all_hosts`
+- Allow running the role even if not all instances are connected
+- Default value: **no**
+
 ### `nomad_version`
 
 - Nomad version to install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,9 @@ os_supported_matrix:
 ## Core
 nomad_debug: false
 
+## Asserts
+nomad_skip_ensure_all_hosts: "{{ lookup('env','NOMAD_SKIP_ENSURE_ALL_HOSTS') | default('false', true) }}"
+
 ### Package
 nomad_version: "{{ lookup('env','NOMAD_VERSION') | default('0.12.1', true) }}"
 nomad_architecture_map:

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -9,6 +9,7 @@
   assert:
     that:
       - ansible_play_hosts == ansible_play_hosts_all
+  when: not nomad_skip_ensure_all_hosts | bool
 
 - name: os_supported_matrix | check distribution
   assert:


### PR DESCRIPTION
Add the nomad_skip_ensure_all_hosts to allow the caller to skip the assert

Fixes #119