### PR TITLE
Install correct python selinux package on Amazon Linux 2

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,6 +6,7 @@ nomad_os_packages:
   - git
   - "{% if ( ansible_distribution  == 'Fedora' and ansible_distribution_version is version('28', '<') ) or \
       ( ansible_distribution  == 'CentOS' and ansible_distribution_version is version('8', '<') ) or \
+      ( ansible_distribution  == 'Amazon' and ansible_distribution_version is version('3', '<') ) or \
       ( ansible_distribution  == 'OracleLinux' and ansible_distribution_version is version('8', '<') ) \
     %}\
       libselinux-python\


### PR DESCRIPTION
Provisioning an Amazon Linux 2 fails, because it cannot find the required package.

Tested with
amzn2-ami-hvm-2.0.20210326.0-x86_64-gp2