### PR TITLE
Allow to configure communication from Nomad to Consul over TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,26 @@ in many Ansible versions, so this feature might not always work.
 - Token to use for consul interaction
 - Default value: **""**
 
+### `nomad_consul_ssl`
+
+- Communicate with Consul over TLS
+- Default value: **false**
+
+### `nomad_consul_ca_file`
+
+- CA certificate used for Consul communication
+- Default value: **""**
+
+### `nomad_consul_cert_file`
+
+- Certificate used for Consul communication. Must also specify `nomad_consul_key_file`.
+- Default value: **""**
+
+### `nomad_consul_key_file`
+
+- Private key used for Consul communication.
+- Default value: **""**
+
 ### `nomad_bootstrap_expect`
 
 - Specifies the number of server nodes to wait for before bootstrapping.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,6 +148,10 @@ nomad_consul_token: ""
 nomad_consul_servers_service_name: "nomad-servers"
 nomad_consul_clients_service_name: "nomad-clients"
 nomad_consul_tags: {}
+nomad_consul_ssl: false
+nomad_consul_ca_file: ""
+nomad_consul_cert_file: ""
+nomad_consul_key_file: ""
 
 ### ACLs
 nomad_acl_enabled: "{{ lookup('env', 'NOMAD_ACL_ENABLED') | default('no', true) }}"

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -34,6 +34,12 @@ consul {
     # Enabling the server and client to bootstrap using Consul.
     server_auto_join = true
     client_auto_join = true
+
+    # Nomad to Consul TLS configuration
+    ssl = {{ nomad_consul_ssl | bool | lower }}
+    ca_file = "{{ nomad_consul_ca_file }}"
+    cert_file = "{{ nomad_consul_cert_file }}"
+    key_file = "{{ nomad_consul_key_file }}"
 }
 {% endif %}
 


### PR DESCRIPTION
- Add TLS related variables to defaults/main.yml
- Update base template
- Update REAME.md with new variables

This configuration is currently impossible to set and is required if you have Consul working over TLS.