### PR TITLE
distro: add support for Flatcar Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@
 os_supported_matrix:
   Archlinux:
     min_version: ''
+  Flatcar:
+    min_version: ''
   # RHEL-based
   RedHat:
     min_version: '6'
@@ -56,6 +58,10 @@ nomad_data_dir: "/var/nomad"
 nomad_plugin_dir: "{{ nomad_data_dir }}/plugins"
 nomad_lockfile: "/var/lock/subsys/nomad"
 nomad_run_dir: "/var/run/nomad"
+
+### Initialization and startup script templates
+nomad_systemd_template: nomad_systemd.service.j2
+nomad_systemd_unit_path: /lib/systemd/system
 
 ### System user and group
 nomad_manage_user: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -182,8 +182,8 @@
 - block:
     - name: systemd script
       template:
-        src: nomad_systemd.service.j2
-        dest: /lib/systemd/system/nomad.service
+        src: "{{ nomad_systemd_template }}"
+        dest: "{{ nomad_systemd_unit_path }}/nomad.service"
         owner: root
         group: root
         mode: 0644

--- a/vars/Flatcar.yml
+++ b/vars/Flatcar.yml
@@ -1,0 +1,6 @@
+---
+# File: Flatcar.yml - Flatcar variables for Nomad
+
+nomad_os_packages: []
+
+nomad_systemd_unit_path: /etc/systemd/system


### PR DESCRIPTION
 - make systemd unit path / template
   configurable.

 - add `Flatcar` to `os_supported_matrix`.

 - add Flatcar.yml to vars folder with
   appropriate distro settings.