### PR TITLE
Fixes custom RPC port for client.

### DIFF
--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -8,7 +8,7 @@ client {
     servers = [
         {%- set comma = joiner(",") -%}
         {%- for server in nomad_servers -%}
-            {{ comma() }}"{{ hostvars[server]['nomad_advertise_address'] | ipwrap }}"
+            {{ comma() }}"{{ hostvars[server]['nomad_advertise_address'] | ipwrap }}:{{ nomad_ports.rpc }}"
         {%- endfor -%} ]
 {% endif %}
 

--- a/templates/nomad_systemd.service.j2
+++ b/templates/nomad_systemd.service.j2
@@ -26,8 +26,8 @@ KillMode=process
 KillSignal=SIGINT
 LimitNOFILE=infinity
 LimitNPROC=infinity
-Restart=on-failure
-RestartSec=42s
+Restart=always
+RestartSec=120
 {% if systemd_version.stdout is version('226', '>=') %}
 TasksMax=infinity
 {% endif %}


### PR DESCRIPTION
At the moment if server if configured with non-default RPC port, client will fail to connect server as when port is not specified it will default to 4647.
From [nomad docs](https://www.nomadproject.io/docs/configuration/client#servers):
```
This may be specified as an IP address or DNS, with or without the port. If the port is omitted, the default port of 4647 is used.
```

I've not added any conditionals since it is expected for RPC port to always be set, and setting explicit value even when using default values could be beneficial for visibility.