### PR TITLE
Set become:false when deleting local gossip key

### DIFF
--- a/tasks/get_gossip_key.yml
+++ b/tasks/get_gossip_key.yml
@@ -70,4 +70,5 @@
       run_once: true
       delegate_to: localhost
       changed_when: false
+      become: false
   no_log: true


### PR DESCRIPTION
The local gossip encryption key at `/tmp/nomad_raw.key` is created using `become: false`. However, during cleanup (`Delete gossip encryption key`) `become: false` is missing and might cause issues becoming root on localhost if sudo asks for a password.

This PR fixes this by addind `become: false` to the respective task in get_gossip_key.yml