### PR TITLE
Remove duplicate Consul TLS configuration from base.hcl. Fixes #146

### DIFF
--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -22,11 +22,8 @@ ports {
 consul {
     # The address to the Consul agent.
     address = "{{ nomad_consul_address }}"
-    ssl = {{ nomad_consul_ssl | bool | lower }}
-    ca_file = "{{ nomad_consul_ca_file }}"
-    cert_file = "{{ nomad_consul_cert_file }}"
-    key_file = "{{ nomad_consul_key_file }}"
     token = "{{ nomad_consul_token }}"
+
     # The service name to register the server and client with Consul.
     server_service_name = "{{ nomad_consul_servers_service_name }}"
     client_service_name = "{{ nomad_consul_clients_service_name }}"


### PR DESCRIPTION
This PR fixes #146 by removing the duplicated Consul TLS configuration lines in base.hcl. 