### PR TITLE
fix yaml list in nomad_plugins

### DIFF
--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -90,6 +90,6 @@ client {
 
 {% for key, value in nomad_plugins.items() %}
 plugin "{{ key }}" {
-{{ plugin_config(value) }}
+{{ plugin_config(value) | replace('\'', '\"') }}
 }
 {% endfor %}


### PR DESCRIPTION
There is no simple solution for converting yaml to hcl2. This is a work
arround until a real converter is availible.

This is related to #127.