### PR TITLE
Harden permissions for nomad directories

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,7 @@
     state: directory
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"
+    mode: "0700"
   with_items:
     - "{{ nomad_data_dir }}"
     - "{{ nomad_plugin_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,7 +62,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: 0700
 
 - name: Base configuration
   template:
@@ -70,7 +70,7 @@
     dest: "{{ nomad_config_dir }}/base.hcl"
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   notify:
     - restart nomad
 
@@ -91,7 +91,7 @@
     dest: "{{ nomad_config_dir }}/server.hcl"
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   when:
     - _nomad_node_server | bool
   notify:
@@ -113,7 +113,7 @@
     dest: "{{ nomad_config_dir }}/client.hcl"
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   when:
     - _nomad_node_client | bool
   notify:
@@ -135,7 +135,7 @@
     dest: "{{ nomad_config_dir }}/custom.json"
     owner: root
     group: root
-    mode: 0644
+    mode: 0600
   when:
     - nomad_config_custom is defined
   notify:

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -8,7 +8,7 @@
         state: directory
         owner: "{{ nomad_user }}"
         group: "{{ nomad_group }}"
-        mode: 0755
+        mode: 0700
 
     - name: Copy CA certificate
       copy:
@@ -17,7 +17,7 @@
         dest: "{{ nomad_tls_dir }}/{{ nomad_ca_file | basename }}"
         owner: "{{ nomad_user }}"
         group: "{{ nomad_group }}"
-        mode: 0644
+        mode: 0600
       notify: restart nomad
 
     - name: Copy certificate
@@ -27,7 +27,7 @@
         dest: "{{ nomad_tls_dir }}/{{ nomad_cert_file | basename }}"
         owner: "{{ nomad_user }}"
         group: "{{ nomad_group }}"
-        mode: 0644
+        mode: 0600
       notify: restart nomad
 
     - name: Copy key


### PR DESCRIPTION
I'm building infrastructure with this and been checking permissions on files.

I've found loose permissions that can be read by anybody on the machine, first, on config files, these can have secret consul tokens and gossip encryption keys.

TLS directory seemed OK as private key is 600 restricted and certs are public.

However, /var/nomad is exposed to all which is extremely severe as below command works and prints vault token of allocation on debian 11 machine:
```
sudo -u nobody cat /var/nomad/alloc/db8014a5-30ca-ad43-6e96-60881fc66f17/run/secrets/vault_token
```

Do with this what you will.