### PR TITLE
Add repo based install similar to ansible-consul and ansible-vault

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,7 @@ os_supported_matrix:
 
 ## Core
 nomad_debug: false
+nomad_install_from_repo: false
 
 ## Asserts
 nomad_skip_ensure_all_hosts: "{{ lookup('env', 'NOMAD_SKIP_ENSURE_ALL_HOSTS') | default('false', true) }}"

--- a/tasks/install_linux_repo.yml
+++ b/tasks/install_linux_repo.yml
@@ -1,0 +1,81 @@
+---
+# File: install_linux_repo.yml - package installation tasks for Nomad
+
+- name: Install OS packages
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ nomad_os_packages }}"
+  tags: installation
+  when: not ansible_facts['os_family'] == "VMware Photon OS"
+
+- name: Populate service facts
+  ansible.builtin.service_facts:
+
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Clean up previous nomad data
+  block:
+    - name: Stop service nomad, if running
+      ansible.builtin.service:
+        name: nomad
+        state: stopped
+      when: ansible_facts.services | join is match('.*nomad.*')
+
+    - name: Remove nomad service unit files from previous installation
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /usr/lib/systemd/system/nomad.service
+        - /etc/init.d/nomad
+
+    - name: Remove the user 'nomad'
+      ansible.builtin.user:
+        name: nomad
+        state: absent
+        remove: yes
+
+  when: "'nomad' not in ansible_facts.packages"
+  become: true
+
+- name: Install repository
+  block:
+    - name: Add Redhat/CentOS/Fedora/Amazon Linux repository
+      ansible.builtin.command: "yum-config-manager --add-repo {{ nomad_repo_url }}"
+      args:
+        creates: /etc/yum.repos.d/hashicorp.repo
+      when: "ansible_os_family|lower == 'redhat'"
+
+    - name: Add an Apt signing key, uses whichever key is at the URL
+      ansible.builtin.apt_key:
+        url: "{{ nomad_repo_url }}/gpg"
+        state: present
+      when: "ansible_os_family|lower == 'debian'"
+
+    - name: Add Debian/Ubuntu Linux repository
+      ansible.builtin.apt_repository:
+        repo: "deb {{ nomad_repo_url }} {{ ansible_distribution_release }} main"
+        state: present
+        update_cache: true
+      when: "ansible_os_family|lower == 'debian'"
+
+  when: "ansible_os_family|lower in [ 'debian', 'redhat' ]"
+  become: true
+
+- name: Install nomad package
+  ansible.builtin.package:
+    name: "nomad{{ '=' if ansible_pkg_mgr == 'apt' else '-' }}{{ nomad_version }}"
+    state: present
+  become: true
+
+- name: Remove default configuration on first install
+  ansible.builtin.file:
+    dest: "{{ nomad_config_dir }}/nomad.hcl"
+    state: absent
+  when: "'nomad' not in ansible_facts.packages"
+  become: true
+  notify:
+    - Restart nomad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,12 @@
 - name: Install OS packages
   ansible.builtin.include_tasks:
     file: install.yml
+  when: not nomad_install_from_repo | bool
+
+- name: Install from repo
+  ansible.builtin.include_tasks:
+    file: install_linux_repo.yml
+  when: nomad_install_from_repo | bool
 
 - name: Disable SELinux (RHEL)
   ansible.builtin.include_tasks:
@@ -95,6 +101,16 @@
     file: tls.yml
   when: nomad_tls_enable | bool
 
+- name: Remove default configuration
+  file:
+    dest: "{{ nomad_config_dir }}/nomad.hcl"
+    state: absent
+  when:
+    - nomad_allow_purge_config | bool
+    - nomad_install_from_repo | bool
+  notify:
+    - restart nomad
+
 - name: Server configuration
   ansible.builtin.template:
     src: server.hcl.j2
@@ -151,7 +167,7 @@
   notify:
     - Restart nomad
 
-- name: Remove custome configuration
+- name: Remove custom configuration
   ansible.builtin.file:
     dest: "{{ nomad_config_dir }}/custom.json"
     state: absent
@@ -183,31 +199,37 @@
     mode: "0755"
   when: not ansible_service_mgr == "systemd" and ansible_os_family == "Debian"
 
-- name: Extract systemd version
-  ansible.builtin.shell:
-    cmd: set -o pipefail && systemctl --version systemd | head -n 1 | cut -d ' ' -f2
-  args:
-    executable: /bin/bash
-  changed_when: false
-  check_mode: false
-  register: systemd_version
+- block:
+  - name: Extract systemd version
+    ansible.builtin.shell:
+      cmd: set -o pipefail && systemctl --version systemd | head -n 1 | cut -d ' ' -f2
+    args:
+      executable: /bin/bash
+    changed_when: false
+    check_mode: false
+    register: systemd_version
+    when:
+      - ansible_service_mgr == "systemd"
+      - not ansible_os_family == "FreeBSD"
+      - not ansible_os_family == "Solaris"
+    tags: skip_ansible_lint
+
+  - name: Create systemd unit
+    ansible.builtin.template:
+      src: "{{ nomad_systemd_template }}"
+      dest: "{{ nomad_systemd_unit_path }}/nomad.service"
+      owner: root
+      group: root
+      mode: "0644"
+    notify:
+      - Reload systemd daemon
+      - Enable nomad at startup (systemd)
+    when: ansible_service_mgr == "systemd"
+
   when:
     - ansible_service_mgr == "systemd"
-    - not ansible_os_family == "FreeBSD"
-    - not ansible_os_family == "Solaris"
-  tags: skip_ansible_lint
-
-- name: Create systemd unit
-  ansible.builtin.template:
-    src: "{{ nomad_systemd_template }}"
-    dest: "{{ nomad_systemd_unit_path }}/nomad.service"
-    owner: root
-    group: root
-    mode: "0644"
-  notify:
-    - Reload systemd daemon
-    - Enable nomad at startup (systemd)
-  when: ansible_service_mgr == "systemd"
+    # Repo install includes systemd files
+    - not nomad_install_from_repo
 
 - name: Start Nomad
   ansible.builtin.service:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -9,3 +9,4 @@ nomad_os_packages:
   - unzip
   - "{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('19', '<')) or (ansible_distribution == 'Debian' and ansible_distribution_version
     is version('11', '<')) %}cgroup-bin{% else %}cgroup-tools{% endif %}"
+nomad_repo_url: "https://apt.releases.hashicorp.com"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,3 +8,9 @@ nomad_os_packages:
     is version('8', '<')) or (ansible_distribution == 'Amazon' and ansible_distribution_version is version('3', '<')) or (ansible_distribution == 'OracleLinux' and
     ansible_distribution_version is version('8', '<')) %}libselinux-python{% else %}python3-libselinux{% endif %}"
   - unzip
+
+nomad_repo_url: "{% if ( ansible_distribution  == 'Fedora') %}\
+      https://rpm.releases.hashicorp.com/fedora/hashicorp.repo\
+    {% else %}\
+      https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo\
+    {% endif %}"


### PR DESCRIPTION
This is implemented to be similar to `ansible-consul` and `ansible-vault`. In fact, it is based on copied configs from `ansible-consul`.