### PR TITLE
Add architecture to checksum files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -212,4 +212,5 @@ nomad_cni_version: "{{ lookup('env','NOMAD_CNI_VERSION') | default('0.9.1', true
 nomad_cni_pkg: "cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }}.tgz"
 nomad_cni_url: "https://github.com/containernetworking/plugins/releases/download/v{{ nomad_cni_version }}"
 nomad_cni_zip_url: "{{ nomad_cni_url }}/{{ nomad_cni_pkg }}"
+nomad_cni_checksum_file: "{{ nomad_cni_pkg }}.sha256"
 nomad_cni_checksum_file_url: "{{ nomad_cni_zip_url }}.sha256"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -213,4 +213,4 @@ nomad_cni_pkg: "cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }
 nomad_cni_url: "https://github.com/containernetworking/plugins/releases/download/v{{ nomad_cni_version }}"
 nomad_cni_zip_url: "{{ nomad_cni_url }}/{{ nomad_cni_pkg }}"
 nomad_cni_checksum_file: "{{ nomad_cni_pkg }}.sha256"
-nomad_cni_checksum_file_url: "{{ nomad_cni_zip_url }}.sha256"
+nomad_cni_checksum_file_url: "{{ nomad_cni_url }}/{{ nomad_cni_checksum_file }}"

--- a/tasks/cni.yml
+++ b/tasks/cni.yml
@@ -10,7 +10,7 @@
 
 - name: Check CNI package checksum file
   stat:
-    path: "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"
+    path: "{{ role_path }}/files/cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }}.sha256"
   become: false
   run_once: true
   tags: installation
@@ -20,7 +20,7 @@
 - name: Get Nomad CNI package checksum file
   get_url:
     url: "{{ nomad_cni_checksum_file_url }}"
-    dest: "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"
+    dest: "{{ role_path }}/files/cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }}.sha256"
   become: false
   run_once: true
   tags: installation
@@ -30,7 +30,7 @@
 - name: Get Nomad CNI package checksum
   shell: |
     set -o pipefail
-    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"  | awk '{print $1}'
+    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }}.sha256"  | awk '{print $1}'
   args:
     executable: /bin/bash
   become: false

--- a/tasks/cni.yml
+++ b/tasks/cni.yml
@@ -10,7 +10,7 @@
 
 - name: Check CNI package checksum file
   stat:
-    path: "{{ role_path }}/files/cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }}.sha256"
+    path: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
   become: false
   run_once: true
   tags: installation
@@ -20,7 +20,7 @@
 - name: Get Nomad CNI package checksum file
   get_url:
     url: "{{ nomad_cni_checksum_file_url }}"
-    dest: "{{ role_path }}/files/cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }}.sha256"
+    dest: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
   become: false
   run_once: true
   tags: installation
@@ -30,7 +30,7 @@
 - name: Get Nomad CNI package checksum
   shell: |
     set -o pipefail
-    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/cni-plugins-linux-{{nomad_architecture}}-v{{ nomad_cni_version }}.sha256"  | awk '{print $1}'
+    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"  | awk '{print $1}'
   args:
     executable: /bin/bash
   become: false


### PR DESCRIPTION
Checksum will fail when using hosts with multiple architectures. As only the first architecture checksum will be avaiable.
This PR separates the checksum files into their own architecture versions.