### PR TITLE
Fix incorrectly documented gc_inode_usage_threshold parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The role defines most of its variables in `defaults/main.yml`:
 - Disk usage threshold percentage for garbage collection
 - Default value: **80**
 
-### `nomad_gc_inodes_usage_threshold`
+### `nomad_gc_inode_usage_threshold`
 
 - Inode usage threshold percentage for garbage collection
 - Default value: **70**


### PR DESCRIPTION
The `gc_inode_usage_threshold` is incorrectly documented.

Refer to

`defaults/main.yml` and `templates/client.hcl.j2`

as well as the nomad documentation: https://developer.hashicorp.com/nomad/docs/configuration/client#gc_disk_usage_threshold