### PR TITLE
feat: support instance hostname for nomad_node_name at runtime

### DIFF
--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -1,5 +1,5 @@
 {% if nomad_node_name is defined and nomad_node_name!="" %}
-    name = "{{ nomad_node_name }}"
+name = "{{ nomad_node_name }}"
 {% endif %}
 region = "{{ nomad_region }}"
 datacenter = "{{ nomad_datacenter }}"

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -1,4 +1,6 @@
-name = "{{ nomad_node_name }}"
+{% if nomad_node_name is defined and nomad_node_name!="" %}
+    name = "{{ nomad_node_name }}"
+{% endif %}
 region = "{{ nomad_region }}"
 datacenter = "{{ nomad_datacenter }}"
 


### PR DESCRIPTION
# Problem

To be able to use this role for golden image being build via Packer, I don't want to set the `nomad_node_name` via ansible and let nomad use the default hostname of the server when the nomad service starts up. The `name` config variable isn't required to run the service.

# Description

This PR will allow users to set the ansible variable `nomad_node_name: null` to allow nomad to use the hostname on startup. This will still be backward compatible for the current usage of nomad_node_name 