### PR TITLE
Fixed Debian install

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ansible.python.interpreterPath": "/bin/python3"
+}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -83,7 +83,7 @@
 
 - name: Install Nomad
   copy:
-    src: "{{ install_temp.path }}/nomad"
+    src: "{{ install_temp.path }}"
     dest: "{{ nomad_bin_dir }}"
     owner: "{{ nomad_user }}"
     group: "{{ nomad_group }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,7 +4,6 @@
 nomad_os_packages:
   - curl
   - git
-  - libcgroup1
   - unzip
   - "{% if ( ansible_distribution  == 'Ubuntu' and ansible_distribution_version is version('19', '<') ) or \
       ( ansible_distribution  == 'Debian' and ansible_distribution_version is version('11', '<') ) \
@@ -12,4 +11,11 @@ nomad_os_packages:
       cgroup-bin\
     {% else %}\
       cgroup-tools\
+    {% endif %}"
+  - "{% if ( ansible_distribution  == 'Ubuntu' and ansible_distribution_version is version('19', '<') ) or \
+      ( ansible_distribution  == 'Debian' and ansible_distribution_version is version('11', '<') ) \
+    %}\
+      libcgroup1\
+    {% else %}\
+      libcgroup2\
     {% endif %}"


### PR DESCRIPTION
Debian packages changed from libcgroup1 to libcgroup2

package copy didn't work from local tmp to remote system - removed filename so entire dir is copied. 