### PR TITLE
Permit to a volume to be created as a file and not only a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ By default, tasks are opted-out of non-default node pools. This means job author
 
 ### `nomad_host_volumes`
 
-- List host_volume is used to make volumes available to jobs (Stateful Workloads).
+- List host_volume is used to make volumes available to jobs (Stateful Workloads). By default, a directory is created. Specify the `state` parameter to change it.
 - Default value: **[]**
 - Example:
 
@@ -348,6 +348,10 @@ nomad_host_volumes:
     group: bin
     mode: 0644
     read_only: false
+  - name: docker socket
+    path: /run/docker.sock
+    read_only: true
+    state: file
 ```
 
 ### `nomad_host_networks`

--- a/tasks/host_volume.yml
+++ b/tasks/host_volume.yml
@@ -3,6 +3,6 @@
     path: "{{ item['path'] }}"
     owner: "{{ item['owner'] | default(nomad_user) }}"
     group: "{{ item['group'] | default(nomad_group) }}"
-    state: directory
+    state: "{{ item['state'] | default('directory') }}"
     mode: "{{ item['mode'] | default('0755') }}"
   with_items: "{{ nomad_host_volumes }}"


### PR DESCRIPTION
In some cases, you may need to mount a file volume (for example, if you want to mount a docker socket).
With this PR, all you need to do is enter the `state ` in the list of volumes in the `nomad_host_volumes `variable. The default value is `directory`.

Example:

```
nomad_host_volumes:
  - name: docker-sock-ro
    path: /run/docker.sock
    state: file
    read_only: true
  - name: postgres-myapp
    path: /volumes/nomad/postgres/myapp
    owner: nobody
    group: nogroup
    mode: "0755"
    read_only: false
```