### PR TITLE
Allow the option to set grpc_ca_file in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,11 @@ in many Ansible versions, so this feature might not always work.
 - Public key of consul CA, use in combination with `nomad_consul_cert_file` and `nomad_consul_key_file`.
 - Default value: ""
 
+### `nomad_consul_grpc_ca_file`
+
+- Public key of consul CA to validate the gRPC TLS, use in combination with `nomad_consul_cert_file` and `nomad_consul_key_file`.
+- Default value: **nomad_consul_ca_file**
+
 ### `nomad_consul_cert_file`
 
 - The public key which can be used to access consul.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,6 +148,7 @@ nomad_use_consul: false
 nomad_consul_address: localhost:8500
 nomad_consul_ssl: false
 nomad_consul_ca_file: ""
+nomad_consul_grpc_ca_file: "{{ nomad_consul_ca_file }}"
 nomad_consul_cert_file: ""
 nomad_consul_key_file: ""
 nomad_consul_token: ""

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -24,6 +24,7 @@ consul {
     address = "{{ nomad_consul_address }}"
     ssl = {{ nomad_consul_ssl | bool | lower }}
     ca_file = "{{ nomad_consul_ca_file }}"
+    grpc_ca_file = "{{ nomad_consul_grpc_ca_file }}"
     cert_file = "{{ nomad_consul_cert_file }}"
     key_file = "{{ nomad_consul_key_file }}"
     token = "{{ nomad_consul_token }}"


### PR DESCRIPTION
This option is required if you want to use consul connect and have gRPC TLS enabled.

It will default to the default CA but can be overwritten if needed.