### PR TITLE
 remove support for end-of-life rhel6 and ubuntu < 20.04,  fix version compare 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ with the following specific software versions:
 * CentOS: 7
 * Debian: 8
 * RHEL: 7
-* Ubuntu: 16.04
+* Ubuntu: >= 20.04
 * unzip for [unarchive module](https://docs.ansible.com/ansible/latest/modules/unarchive_module.html#notes)
 
 ## Role Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ os_supported_matrix:
     min_version: ""
   # RHEL-based
   RedHat:
-    min_version: "6"
+    min_version: "7"
   CentOS:
     min_version: "7"
   Fedora:

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -31,7 +31,7 @@
     quiet: true
     fail_msg: "{{ ansible_distribution_version }} is not supported for this role"
     that:
-      - ansible_distribution_version is version(version_to_compare, '>')
+      - ansible_distribution_version is version(version_to_compare, '>=')
   when:
     - version_to_compare is defined
     - version_to_compare | length > 0

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -1,28 +1,4 @@
 ---
-# File: docker.yml - Docker tasks for nomad
-
-## Docker items
-
-# Fix for https://github.com/docker/docker/issues/23347
-- name: Install dmsetup for Ubuntu 16.04
-  ansible.builtin.apt:
-    pkg: dmsetup
-    state: present
-    update_cache: true
-    cache_valid_time: 600
-  register: dmsetup_result
-  when:
-    - ansible_os_family == "Debian"
-    - ansible_distribution_version is version_compare(16.04, '=')
-    - nomad_docker_dmsetup | bool
-
-- name: Run dmsetup for Ubuntu 16.04 # noqa no-changed-when
-  ansible.builtin.command:
-    cmd: dmsetup mknodes
-  when:
-    - nomad_docker_dmsetup | bool
-    - dmsetup_result
-
 - name: Add Nomad user to docker group
   ansible.builtin.user:
     name: "{{ nomad_user }}"


### PR DESCRIPTION
fixes #186 