### PR TITLE
Adding support for JWT auth to vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add host_volume for nomad client (thanks @ducminhle)
 - Update CONTRIBUTORS
 - Update documentation
+- Add support for vault identity instead of using a vault_token
 
 ## 1.9.5
 

--- a/README.md
+++ b/README.md
@@ -584,8 +584,19 @@ in many Ansible versions, so this feature might not always work.
 
 ### `nomad_vault_create_from_role`
 
-- Role to create tokens from
+- Role to create tokens from, is is a legacy setting since the prefered way to configuring it is using workload identity.
 - Default value: **""**
+
+### `nomad_vault_default_identity`
+
+- Authenticate using a JWT aud bound policy, this is the prefered way of linking nomad to vault, see the [docs](https://developer.hashicorp.com/nomad/tutorials/integrate-vault/vault-acl)
+  To use this config set it to `vault.io` for example, default is it disabled.
+- Default value: **""**
+
+### `nomad_vault_default_identity_ttl`
+
+- Optional value for the TTL of the default identity
+- Default value: **1h**
 
 ### `nomad_vault_ca_file`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,6 +166,8 @@ nomad_vault_enabled: "{{ lookup('env', 'NOMAD_VAULT_ENABLED') | default('no', tr
 nomad_vault_address: "{{ vault_address | default('0.0.0.0', true) }}"
 nomad_vault_allow_unauthenticated: true
 nomad_vault_create_from_role: ""
+nomad_vault_default_identity: ""
+nomad_vault_default_identity_ttl: "1h"
 nomad_vault_task_token_ttl: ""
 nomad_vault_ca_file: ""
 nomad_vault_ca_path: ""

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -74,7 +74,9 @@ vault {
     enabled = {{ nomad_vault_enabled | bool | lower }}
     address = "{{ nomad_vault_address }}"
     allow_unauthenticated = {{ nomad_vault_allow_unauthenticated | bool | lower }}
+{%if nomad_vault_create_from_role != "" %}
     create_from_role = "{{ nomad_vault_create_from_role }}"
+{% endif %}
     task_token_ttl = "{{ nomad_vault_task_token_ttl }}"
     ca_file = "{{ nomad_vault_ca_file }}"
     ca_path = "{{ nomad_vault_ca_path }}"
@@ -82,7 +84,13 @@ vault {
     key_file = "{{ nomad_vault_key_file }}"
     tls_server_name = "{{ nomad_vault_tls_server_name }}"
     tls_skip_verify = {{ nomad_vault_tls_skip_verify | bool | lower }}
-{%if nomad_node_role != 'client' %}
+{%if nomad_vault_default_identity != "" %}
+    default_identity {
+      aud = ["{{ nomad_vault_default_identity }}"]
+      ttl = "{{ nomad_vault_default_identity_ttl }}"
+    }
+{% endif %}
+{%if nomad_node_role != 'client' and nomad_vault_token != ""  %}
     token = "{{ nomad_vault_token }}"
 {% endif %}
     namespace = "{{ nomad_vault_namespace }}"


### PR DESCRIPTION
In newer versions of nomad you get this warning:

```
agent: Setting a Vault token in the agent configuration is deprecated and will be removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.
```

This PR adds a default idenity section the config if set, so that we don't break older nomad versions.