### PR TITLE
Add support for 'nomad_raft_multiplier' server config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ The role defines most of its variables in `defaults/main.yml`:
 - Set the encryption key; should be the same across a cluster. If not present and `nomad_encrypt_enable` is true, the key will be generated & retrieved from the bootstrapped server.
 - Default value: **""**
 
+### `nomad_raft_multiplier`
+
+- Specifies the raft multiplier to use
+- Default value: **1**
+
 ### `nomad_raft_protocol`
 
 - Specifies the version of raft protocal, which used by nomad servers for communication

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,6 +101,7 @@ nomad_eval_gc_threshold: 1h
 nomad_deployment_gc_threshold: 1h
 nomad_encrypt_enable: "{{ lookup('env', 'NOMAD_ENCRYPT_ENABLE') | default('false', true) }}"
 nomad_raft_protocol: 2
+nomad_raft_multiplier: 1
 
 #### Client settings
 nomad_node_class: ""

--- a/templates/server.hcl.j2
+++ b/templates/server.hcl.j2
@@ -43,5 +43,6 @@ authoritative_region = "{{ nomad_authoritative_region }}"
 
     encrypt = "{{ nomad_encrypt | default('') }}"
 
+    raft_multiplier = {{ nomad_raft_multiplier }}
     raft_protocol = {{ nomad_raft_protocol }}
 }


### PR DESCRIPTION
Add support for the nomad option `raft_multiplier`.
Default to 1 as defined in https://developer.hashicorp.com/nomad/docs/configuration/server#raft_multiplier.