### PR TITLE
Fix incorrectly inserted endif with d237a77743116a75ab44581f2f2721f23…

### DIFF
--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -96,13 +96,13 @@ client {
     template {
     {{ template_config(nomad_template_config) | replace('\'', '\"') }}
     }
+    {% endif %}
 
     {% if nomad_artifact -%}
     artifact {
     {% for key, value in nomad_artifact.items() %}
     "{{ key }}" = "{{ value }}"
     {% endfor -%}
-    {% endif %}
     }
     {% endif %}
 }


### PR DESCRIPTION
With https://github.com/ansible-community/ansible-nomad/pull/189 incorrect `endif` and `end` brackets have been introduced making a nomad client unable to start.
Could only happen when `nomad_template_config` is used, unfortunately not sufficiently tested (?)