### PR TITLE
Ensure that OS package conflicts can be handled properly

### DIFF
--- a/molecule/_shared/Dockerfile.j2
+++ b/molecule/_shared/Dockerfile.j2
@@ -18,7 +18,7 @@ RUN if [ $(command -v apt-get) ]; then \
         if grep -q "Debian GNU/Linux 10" /etc/os-release; then \
             apt-get update && apt-get install -y systemd python sudo bash ca-certificates iproute2 python-apt python-apt-common && apt-get clean; \
         elif grep -q "Debian GNU/Linux 11" /etc/os-release; then \
-            apt-get update && apt-get install -y systemd python sudo bash ca-certificates iproute2 python-apt python-apt-common && apt-get clean; \
+            apt-get update && apt-get install -y systemd python sudo bash ca-certificates iproute2 python3-apt python-apt-common && apt-get clean; \
         else \
             apt-get update && apt-get install -y systemd python3 sudo bash ca-certificates iproute2 python3-apt && apt-get clean; \
         fi \

--- a/molecule/_shared/Dockerfile.j2
+++ b/molecule/_shared/Dockerfile.j2
@@ -16,9 +16,9 @@ ENV {{ var }} {{ value }}
 
 RUN if [ $(command -v apt-get) ]; then \
         if grep -q "Debian GNU/Linux 10" /etc/os-release; then \
-            apt-get update && apt-get install -y systemd python sudo bash ca-certificates iproute2 python-apt-common && apt-get clean; \
+            apt-get update && apt-get install -y systemd python sudo bash ca-certificates iproute2 python-apt python-apt-common && apt-get clean; \
         elif grep -q "Debian GNU/Linux 11" /etc/os-release; then \
-            apt-get update && apt-get install -y systemd python sudo bash ca-certificates iproute2 python-apt-common && apt-get clean; \
+            apt-get update && apt-get install -y systemd python sudo bash ca-certificates iproute2 python-apt python-apt-common && apt-get clean; \
         else \
             apt-get update && apt-get install -y systemd python3 sudo bash ca-certificates iproute2 python3-apt && apt-get clean; \
         fi \

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,17 +1,36 @@
 ---
 # File: install.yml - package installation tasks for Nomad  # noqa 106
 
+- name: Gather the OS packages
+  ansible.builtin.package_facts:
+    manager: auto
+  tags: installation
+
+- name: Initialize a fact with the OS packages to install
+  ansible.builtin.set_fact:
+    nomad_os_packages_fact: []
+  tags: installation
+
+- name: Set a fact with the OS packages to really install
+  ansible.builtin.set_fact:
+    nomad_os_packages_fact: "{{ nomad_os_packages_fact + [item] }}"
+  with_items: "{{ nomad_os_packages }}"
+  tags: installation
+  when:
+    - item.handle is not defined or item.handle != 'skip'
+    - item.conflicts is not defined or item.conflicts not in ansible_facts.packages
+
 - name: Install OS packages
   ansible.builtin.package:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     state: present
-  with_items: "{{ nomad_os_packages }}"
+  with_items: "{{ nomad_os_packages_fact }}"
   tags: installation
   when: not ansible_facts['os_family'] == "VMware Photon OS"
 
 - name: Install OS packages # noqa no-changed-when
-  ansible.builtin.command: tdnf install {{ item }}
-  with_items: "{{ nomad_os_packages }}"
+  ansible.builtin.command: tdnf install {{ item.name }}
+  with_items: "{{ nomad_os_packages_fact }}"
   tags: installation
   when: ansible_facts['os_family'] == "VMware Photon OS"
 

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -2,6 +2,6 @@
 # File: Archlinux.yml - Archlinux variables for Nomad
 
 nomad_os_packages:
-  - unzip
+  - name: unzip
 
 nomad_syslog_enable: false

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,10 +2,10 @@
 # File: vars/Debian.yml - Debian OS variables for Nomad
 
 nomad_os_packages:
-  - curl
-  - git
-  - "{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('22.10', '<')) or (ansible_distribution == 'Debian' and ansible_distribution_version
-    is version('12', '<')) %}libcgroup1{% else %}libcgroup2{% endif %}"
-  - unzip
-  - "{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('19', '<')) or (ansible_distribution == 'Debian' and ansible_distribution_version
-    is version('11', '<')) %}cgroup-bin{% else %}cgroup-tools{% endif %}"
+  - name: curl
+  - name: git
+  - name: "{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('22.10', '<'))
+                or (ansible_distribution == 'Debian' and ansible_distribution_version is version('12', '<')) %}libcgroup1{% else %}libcgroup2{% endif %}"
+  - name: unzip
+  - name: "{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('19', '<'))
+                or (ansible_distribution == 'Debian' and ansible_distribution_version is version('11', '<')) %}cgroup-bin{% else %}cgroup-tools{% endif %}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,9 +2,12 @@
 # File: vars/RedHat.yml - Red Hat OS variables for Nomad
 
 nomad_os_packages:
-  - "{% if (ansible_distribution == 'AlmaLinux' and ansible_distribution_version is version('9', '>=')) %}curl-minimal{% else %}curl{% endif %}"
-  - git
-  - "{% if (ansible_distribution == 'Fedora' and ansible_distribution_version is version('28', '<')) or (ansible_distribution == 'CentOS' and ansible_distribution_version
-    is version('8', '<')) or (ansible_distribution == 'Amazon' and ansible_distribution_version is version('3', '<')) or (ansible_distribution == 'OracleLinux' and
-    ansible_distribution_version is version('8', '<')) %}libselinux-python{% else %}python3-libselinux{% endif %}"
-  - unzip
+  - name: curl
+    conflicts: curl-minimal
+    handle: skip
+  - name: git
+  - name: "{% if (ansible_distribution == 'Fedora' and ansible_distribution_version is version('28', '<'))
+                or (ansible_distribution == 'CentOS' and ansible_distribution_version is version('8', '<'))
+                or (ansible_distribution == 'Amazon' and ansible_distribution_version is version('3', '<'))
+                or (ansible_distribution == 'OracleLinux' and ansible_distribution_version is version('8', '<')) %}libselinux-python{% else %}python3-libselinux{% endif %}"
+  - name: unzip

--- a/vars/VMware Photon OS.yml
+++ b/vars/VMware Photon OS.yml
@@ -1,3 +1,3 @@
 ---
 nomad_os_packages:
-  - unzip
+  - name: unzip


### PR DESCRIPTION
With https://github.com/ansible-community/ansible-nomad/pull/191 a conditional was introduced to not fail if `curl-minimal` is installed rather than curl in case of almalinux:9 docker image:

```
 "{% if (ansible_distribution == 'AlmaLinux' and ansible_distribution_version is version('9', '>=')) %}curl-minimal{% else %}curl{% endif %}"
```
In (at least) almalinux 9 both variants is possible.

This PR extends the possibility for the `nomad_os_packages` to declare potential conflicts and have them handled accordingly:

```
nomad_os_packages:
  - name: curl
    conflicts: curl-minimal
    handle: skip
```

Execution:

1. Gather the OS packages using `ansible.builtin.package_facts`
2. A fact is set that considers a package only if the conflicting package is not installed *or* `handle` is not set to `skip`