### PR TITLE
Fix: bug fixes

### DIFF
--- a/tasks/cni.yml
+++ b/tasks/cni.yml
@@ -22,8 +22,6 @@
   ansible.builtin.get_url:
     url: "{{ nomad_cni_checksum_file_url }}"
     dest: "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"
-    owner: "{{ nomad_user }}"
-    group: "{{ nomad_group }}"
     mode: "0640"
   become: false
   run_once: true
@@ -53,8 +51,6 @@
   ansible.builtin.get_url:
     url: "{{ nomad_cni_zip_url }}"
     dest: "{{ role_path }}/files/{{ nomad_cni_pkg }}"
-    owner: "{{ nomad_user }}"
-    group: "{{ nomad_group }}"
     mode: "0640"
     checksum: sha256:{{ nomad_cni_sha256.stdout }}
     timeout: "42"

--- a/tasks/get_gossip_key.yml
+++ b/tasks/get_gossip_key.yml
@@ -50,6 +50,12 @@
         - name: Generate gossip encryption key # noqa no-changed-when
           ansible.builtin.command:
             cmd: nomad operator keygen
+          when: nomad_version is version('1.4.0', '<')
+          register: nomad_keygen
+        - name: Generate gossip encryption key # noqa no-changed-when
+          ansible.builtin.command:
+            cmd: nomad operator gossip keyring generate
+          when: nomad_version is version('1.4.0', '>=')
           register: nomad_keygen
 
         - name: Write key locally to share with other nodes

--- a/tasks/install_podman.yml
+++ b/tasks/install_podman.yml
@@ -14,8 +14,6 @@
   ansible.builtin.get_url:
     url: "{{ nomad_podman_checksum_file_url }}"
     dest: "{{ role_path }}/files/nomad_podman_{{ nomad_podman_version }}_SHA256SUMS"
-    owner: "{{ nomad_user }}"
-    group: "{{ nomad_group }}"
     mode: "0640"
   become: false
   run_once: true
@@ -45,8 +43,6 @@
   ansible.builtin.get_url:
     url: "{{ nomad_podman_zip_url }}"
     dest: "{{ role_path }}/files/{{ nomad_podman_pkg }}"
-    owner: "{{ nomad_user }}"
-    group: "{{ nomad_group }}"
     mode: "0640"
     checksum: sha256:{{ nomad_podman_sha256.stdout }}
     timeout: "42"


### PR DESCRIPTION
- Fix: do not use nomad_user/nomad_group when a task is delegated to local host
  Using the nomad_user/nomad_group when task is delegated to localhost (i.e the control machine) only works if the user/group exists and has access to the directory/files specified.
- Fix gossip key generation for nomad versions >= 1.4.0 