### PR TITLE
Allow configuring the interface for the individual services

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,9 @@ nomad_region: global
 nomad_log_level: INFO
 nomad_syslog_enable: true
 nomad_iface: "{{ lookup('env', 'NOMAD_IFACE') | default(ansible_default_ipv4.interface, true) }}"
+nomad_iface_http: "{{ lookup('env', 'NOMAD_IFACE') | default(ansible_default_ipv4.interface, true) }}"
+nomad_iface_rpc: "{{ lookup('env', 'NOMAD_IFACE') | default(ansible_default_ipv4.interface, true) }}"
+nomad_iface_serf: "{{ lookup('env', 'NOMAD_IFACE') | default(ansible_default_ipv4.interface, true) }}"
 nomad_node_name: "{{ inventory_hostname_short }}"
 nomad_node_role: "{{ lookup('env', 'NOMAD_NODE_ROLE') | default('client', true) }}"
 nomad_leave_on_terminate: true
@@ -131,7 +134,16 @@ nomad_plugins: {}
 nomad_template_config: {}
 ### Addresses
 nomad_bind_address: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface]['ipv4']['address'] }}"
+
+nomad_bind_address_http: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface_http]['ipv4']['address'] }}"
+nomad_bind_address_rpc: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface_rpc]['ipv4']['address'] }}"
+nomad_bind_address_serf: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface_serf]['ipv4']['address'] }}"
+
 nomad_advertise_address: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface]['ipv4']['address'] }}"
+
+nomad_advertise_address_http: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface_http]['ipv4']['address'] }}"
+nomad_advertise_address_rpc: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface_rpc]['ipv4']['address'] }}"
+nomad_advertise_address_serf: "{{ hostvars[inventory_hostname]['ansible_' + nomad_iface_serf]['ipv4']['address'] }}"
 
 ### Ports
 nomad_ports:

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -7,10 +7,15 @@ disable_update_check = {{ nomad_disable_update_check | bool | lower }}
 
 
 bind_addr = "{{ nomad_bind_address }}"
+addresses {
+    http = "{{ nomad_bind_address_http }}"
+    rpc = "{{ nomad_bind_address_rpc }}"
+    serf = "{{ nomad_bind_address_serf }}"
+}
 advertise {
-    http = "{{ nomad_advertise_address }}:{{ nomad_ports.http }}"
-    rpc = "{{ nomad_advertise_address }}:{{ nomad_ports.rpc }}"
-    serf = "{{ nomad_advertise_address }}:{{ nomad_ports.serf }}"
+    http = "{{ nomad_advertise_address_http }}:{{ nomad_ports.http }}"
+    rpc = "{{ nomad_advertise_address_rpc }}:{{ nomad_ports.rpc }}"
+    serf = "{{ nomad_advertise_address_serf }}:{{ nomad_ports.serf }}"
 }
 ports {
     http = {{ nomad_ports['http'] }}


### PR DESCRIPTION
The interfaces for the services (http, rpc and serf) in nomad can be configured individually so that they can appear on different networks.

For instance, one might want to generally use the localnet of the cloud project for communication between nomad nodes, but one would like the http service availabe over tailscale.

This change allows for this configuration flexibility to be exposed in the nomad role.