### PR TITLE
Fix installation of cni plugins on hosts with different archs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -217,4 +217,5 @@ nomad_cni_version: "{{ lookup('env', 'NOMAD_CNI_VERSION') | default('0.9.1', tru
 nomad_cni_pkg: cni-plugins-linux-{{ nomad_architecture }}-v{{ nomad_cni_version }}.tgz
 nomad_cni_url: https://github.com/containernetworking/plugins/releases/download/v{{ nomad_cni_version }}
 nomad_cni_zip_url: "{{ nomad_cni_url }}/{{ nomad_cni_pkg }}"
+nomad_cni_checksum_file: "{{ nomad_cni_pkg }}.sha256"
 nomad_cni_checksum_file_url: "{{ nomad_cni_zip_url }}.sha256"

--- a/tasks/cni.yml
+++ b/tasks/cni.yml
@@ -11,9 +11,8 @@
 
 - name: Check CNI package checksum file
   ansible.builtin.stat:
-    path: "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"
+    path: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
   become: false
-  run_once: true
   tags: installation
   register: nomad_cni_checksum
   delegate_to: 127.0.0.1
@@ -21,10 +20,9 @@
 - name: Get Nomad CNI package checksum file
   ansible.builtin.get_url:
     url: "{{ nomad_cni_checksum_file_url }}"
-    dest: "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"
+    dest: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
     mode: "0640"
   become: false
-  run_once: true
   tags: installation
   when: not nomad_cni_checksum.stat.exists
   delegate_to: 127.0.0.1
@@ -32,7 +30,7 @@
 - name: Get Nomad CNI package checksum # noqa no-changed-when
   ansible.builtin.shell: |
     set -o pipefail
-    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"  | awk '{print $1}'
+    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"  | awk '{print $1}'
   args:
     executable: /bin/bash
   become: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,7 +151,7 @@
   notify:
     - Restart nomad
 
-- name: Remove custome configuration
+- name: Remove custom configuration
   ansible.builtin.file:
     dest: "{{ nomad_config_dir }}/custom.json"
     state: absent


### PR DESCRIPTION
Before only one sha was being downloaded for checking against even if each host required a different cni plugin distribution.