### PR TITLE
Stop redownloading cni

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -217,4 +217,5 @@ nomad_cni_version: "{{ lookup('env', 'NOMAD_CNI_VERSION') | default('0.9.1', tru
 nomad_cni_pkg: cni-plugins-linux-{{ nomad_architecture }}-v{{ nomad_cni_version }}.tgz
 nomad_cni_url: https://github.com/containernetworking/plugins/releases/download/v{{ nomad_cni_version }}
 nomad_cni_zip_url: "{{ nomad_cni_url }}/{{ nomad_cni_pkg }}"
+nomad_cni_checksum_file: "{{ nomad_cni_pkg }}.sha256"
 nomad_cni_checksum_file_url: "{{ nomad_cni_zip_url }}.sha256"

--- a/tasks/cni.yml
+++ b/tasks/cni.yml
@@ -11,9 +11,8 @@
 
 - name: Check CNI package checksum file
   ansible.builtin.stat:
-    path: "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"
+    path: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
   become: false
-  run_once: true
   tags: installation
   register: nomad_cni_checksum
   delegate_to: 127.0.0.1
@@ -21,10 +20,9 @@
 - name: Get Nomad CNI package checksum file
   ansible.builtin.get_url:
     url: "{{ nomad_cni_checksum_file_url }}"
-    dest: "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"
+    dest: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
     mode: "0640"
   become: false
-  run_once: true
   tags: installation
   when: not nomad_cni_checksum.stat.exists
   delegate_to: 127.0.0.1
@@ -32,7 +30,7 @@
 - name: Get Nomad CNI package checksum # noqa no-changed-when
   ansible.builtin.shell: |
     set -o pipefail
-    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/nomad_cni_{{ nomad_cni_version }}_SHA256SUMS"  | awk '{print $1}'
+    grep "{{ nomad_cni_pkg }}" "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"  | awk '{print $1}'
   args:
     executable: /bin/bash
   become: false

--- a/tasks/cni.yml
+++ b/tasks/cni.yml
@@ -27,6 +27,24 @@
   when: not nomad_cni_checksum.stat.exists
   delegate_to: 127.0.0.1
 
+- name: Re-check CNI package checksum file
+  ansible.builtin.stat:
+    path: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
+  become: false
+  tags: installation
+  register: nomad_cni_checksum
+  delegate_to: 127.0.0.1
+
+- name: Read previously installed checksum
+  ansible.builtin.stat:
+    path: "{{ nomad_cni_dir }}/{{ nomad_cni_checksum_file }}"
+  tags: installation
+  register: nomad_cni_remote_checksum
+
+- name: Check if new CNI should be installed
+  ansible.builtin.set_fact:
+    nomad_should_install_cni: "{{ not nomad_cni_remote_checksum.stat.exists or nomad_cni_remote_checksum.stat.checksum != nomad_cni_checksum.stat.checksum }}"
+
 - name: Get Nomad CNI package checksum # noqa no-changed-when
   ansible.builtin.shell: |
     set -o pipefail
@@ -37,6 +55,7 @@
   register: nomad_cni_sha256
   tags: installation
   delegate_to: 127.0.0.1
+  when: nomad_should_install_cni
 
 - name: Check Nomad CNI package file
   ansible.builtin.stat:
@@ -44,6 +63,7 @@
   become: false
   register: nomad_cni_package
   delegate_to: 127.0.0.1
+  when: nomad_should_install_cni
 
 - name: Download Nomad CNI
   ansible.builtin.get_url:
@@ -55,7 +75,9 @@
   become: false
   tags: installation
   delegate_to: 127.0.0.1
-  when: not nomad_cni_package.stat.exists
+  when:
+    - nomad_should_install_cni
+    - not nomad_cni_package.stat.exists
 
 - name: Create Temporary Directory for Extraction
   ansible.builtin.tempfile:
@@ -65,6 +87,7 @@
   register: install_temp
   tags: installation
   delegate_to: 127.0.0.1
+  when: nomad_should_install_cni
 
 - name: Unarchive Nomad CNI
   ansible.builtin.unarchive:
@@ -74,6 +97,7 @@
   become: false
   tags: installation
   delegate_to: 127.0.0.1
+  when: nomad_should_install_cni
 
 - name: Install Nomad CNI
   ansible.builtin.copy:
@@ -86,6 +110,14 @@
     - "{{ install_temp.path }}/*"
   tags: installation
   notify: Restart nomad
+  when: nomad_should_install_cni
+
+- name: Save install checksum record
+  copy:
+    src: "{{ role_path }}/files/{{ nomad_cni_checksum_file }}"
+    dest: "{{ nomad_cni_dir }}"
+  tags: installation
+  when: nomad_should_install_cni
 
 - name: Cleanup
   ansible.builtin.file:
@@ -94,3 +126,4 @@
   become: false
   tags: installation
   delegate_to: 127.0.0.1
+  when: nomad_should_install_cni

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,7 +151,7 @@
   notify:
     - Restart nomad
 
-- name: Remove custome configuration
+- name: Remove custom configuration
   ansible.builtin.file:
     dest: "{{ nomad_config_dir }}/custom.json"
     state: absent


### PR DESCRIPTION
The previous implementation redownloads CNI plugins every run. This compares the sha first.

This depends on #156. I'll rebase and undraft after that is merged.
