### PR TITLE
misc: improve robustness of host_volume task and client template

### DIFF
--- a/tasks/host_volume.yml
+++ b/tasks/host_volume.yml
@@ -1,9 +1,12 @@
 ---
-- name: Create volume {{ item['name'] }}
+
+- name: Create volume directories
   ansible.builtin.file:
-    path: "{{ item['path'] }}"
-    owner: "{{ item['owner'] | default(nomad_user) }}"
-    group: "{{ item['group'] | default(nomad_group) }}"
-    state: "{{ item['state'] | default('directory') }}"
-    mode: "{{ item['mode'] | default('0755') }}"
-  with_items: "{{ nomad_host_volumes }}"
+    path: "{{ item.path }}"
+    owner: "{{ item.owner | default(nomad_user) }}"
+    group: "{{ item.group | default(nomad_group) }}"
+    state: "{{ item.state | default('directory') }}"
+    mode: "{{ item.mode | default('0755') }}"
+  loop: "{{ nomad_host_volumes | default([]) }}"
+  loop_control:
+    label: "{{ item.name | default(item.path) }}"

--- a/templates/client.hcl.j2
+++ b/templates/client.hcl.j2
@@ -54,7 +54,7 @@ client {
     }
 {% endfor %}
 
-    {% if nomad_chroot_env != False -%}
+    {% if nomad_chroot_env is mapping and nomad_chroot_env | length > 0 -%}
     chroot_env = {
     {% for key, value in nomad_chroot_env.items() %}
     "{{ key }}" = "{{ value }}"


### PR DESCRIPTION
- switch to safer variable handling and loop usage in host_volume task.

- guard nomad_chroot_env with `is mapping` to avoid .items() crashes.